### PR TITLE
feat: macos support

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,12 +4,8 @@
     .version = "0.0.0",
     .dependencies = .{
         .libgit2 = .{
-            .url = "git+https://github.com/allyourcodebase/libgit2#fabb23633d7cdbf55e82993fa0d2f0a4a2fff3c2",
-            .hash = "libgit2-1.9.0-uizqTS9mAACnFpt2pKeMXSjHxzL1Ux0U85n9WXgzGghW",
-        },
-        .libgit2_c = .{
-            .url = "git+https://github.com/libgit2/libgit2?ref=v1.9.0#338e6fb681369ff0537719095e22ce9dc602dbf0",
-            .hash = "N-V-__8AAJbmLwHHxHDWkz0i6WIR6FpNe6tXSLzaPuWtvBBg",
+            .url = "git+https://github.com/allyourcodebase/libgit2#84e36893aeba58800a88253477cc2faf0fd27ae7",
+            .hash = "libgit2-1.9.0-uizqTVXSAAAH3Cp1D9gGmg2VgGEenOOY1hZ2H07qw2T9",
         },
     },
     .paths = .{

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -4,25 +4,25 @@ const builtin = @import("builtin");
 const log_scope = std.log.scoped(.gitz);
 
 pub fn err(comptime format: []const u8, args: anytype) void {
-    comptime if (!builtin.is_test) {
+    if (!builtin.is_test) {
         log_scope.err(format, args);
-    };
+    }
 }
 
 pub fn warn(comptime format: []const u8, args: anytype) void {
-    comptime if (!builtin.is_test) {
+    if (!builtin.is_test) {
         log_scope.warn(format, args);
-    };
+    }
 }
 
 pub fn info(comptime format: []const u8, args: anytype) void {
-    comptime if (!builtin.is_test) {
+    if (!builtin.is_test) {
         log_scope.info(format, args);
-    };
+    }
 }
 
 pub fn debug(comptime format: []const u8, args: anytype) void {
-    comptime if (!builtin.is_test) {
+    if (!builtin.is_test) {
         log_scope.debug(format, args);
-    };
+    }
 }

--- a/tests/harness.sh
+++ b/tests/harness.sh
@@ -20,6 +20,7 @@ mkdir empty
 pushd empty
 git init
 git branch -m main
+echo -e "[init]\ndefaultBranch = main" >> .git/config
 popd
 
 mkdir discover


### PR DESCRIPTION
This also fixes the logger that worked in tests but failed to build correctly.

Also use the `TlsBackend` provided by the libgit2
package so that we stop having to track the type
ourselves.